### PR TITLE
Prepare BasePulse for production deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+pnpm-store
+.git
+.github
+.env
+.env.*
+!.env.example
+.manus-logs
+dist
+coverage
+.vscode
+.DS_Store
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# BasePulse production container
+FROM node:22-bookworm-slim AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+WORKDIR /app
+
+FROM base AS deps
+COPY package.json pnpm-lock.yaml* ./
+RUN if [ -f pnpm-lock.yaml ]; then pnpm install --frozen-lockfile; else pnpm install; fi
+
+FROM deps AS build
+COPY . .
+ENV NODE_ENV=production
+RUN pnpm build
+
+FROM base AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./package.json
+EXPOSE 3000
+CMD ["pnpm", "start"]

--- a/PRODUCTION_DEPLOYMENT.md
+++ b/PRODUCTION_DEPLOYMENT.md
@@ -1,0 +1,131 @@
+# BasePulse Production Deployment
+
+This guide is for moving BasePulse off the temporary Manus URL and onto a stable production host.
+
+## What changed
+
+This repo now includes:
+
+- `Dockerfile` for production container builds
+- `railway.json` for Railway deployment
+- `/healthz` health-check endpoint
+- Safer autonomous-agent startup controlled by `BASEPULSE_AGENT_ENABLED`
+
+By default, the dashboard can run without automatically starting the token-deployment loop. Turn the agent loop on only after secrets, wallet funding, and safety limits are correct.
+
+## Recommended host
+
+Use Railway first because BasePulse needs a long-running Node server and a MySQL database.
+
+## Deploy on Railway
+
+1. Go to Railway and create a new project.
+2. Choose **Deploy from GitHub repo**.
+3. Select `Abuchtela/BasePulse`.
+4. Add a MySQL database service.
+5. Copy the MySQL connection URL into the app service as `DATABASE_URL`.
+6. Add the required environment variables listed below.
+7. Deploy.
+8. Open `/healthz` on the deployed URL to confirm the server is alive.
+9. Open `/dashboard` to view the BasePulse dashboard.
+
+## Required environment variables
+
+Minimum for the web server/database:
+
+```bash
+NODE_ENV=production
+DATABASE_URL=mysql://USER:PASSWORD@HOST:PORT/DATABASE
+BASEPULSE_AGENT_ENABLED=false
+```
+
+Recommended Base/API variables:
+
+```bash
+BASE_API_KEY=
+BASE_BUILDER_CODE=bc_hi2cipof
+CDP_API_KEY_NAME=
+CDP_API_KEY_PRIVATE_KEY=
+```
+
+Only set these when you are ready for autonomous/onchain behavior:
+
+```bash
+BASEPULSE_AGENT_ENABLED=true
+BASEPULSE_AGENT_INTERVAL_MINUTES=15
+BASEPULSE_MIN_SENTIMENT_SCORE=60
+BASEPULSE_MIN_MENTIONS=5
+BASEPULSE_MIN_VOLUME_24H_USD=100000
+BASEPULSE_MAX_DEPLOYMENTS_PER_DAY=10
+AGENT_PRIVATE_KEY=
+AGENT_OWNER_OPENID=
+```
+
+Social/API integrations:
+
+```bash
+X_API_KEY=
+X_API_SECRET=
+X_ACCESS_TOKEN=
+X_ACCESS_TOKEN_SECRET=
+NEYNAR_API_KEY=
+```
+
+Analytics, optional:
+
+```bash
+VITE_ANALYTICS_ENDPOINT=
+VITE_ANALYTICS_WEBSITE_ID=
+```
+
+## Important safety note
+
+Do not enable `BASEPULSE_AGENT_ENABLED=true` until:
+
+- The agent wallet is funded only with money you are willing to risk.
+- `BASEPULSE_MAX_DEPLOYMENTS_PER_DAY` is set conservatively.
+- You have confirmed token deployment behavior on a test setup.
+- Private keys are stored only in the hosting provider's secret/environment settings.
+
+Never commit `.env`, private keys, API keys, seed phrases, or database credentials to GitHub.
+
+## Health check
+
+After deployment, visit:
+
+```text
+https://YOUR-APP-URL/healthz
+```
+
+Expected response:
+
+```json
+{
+  "status": "ok",
+  "service": "basepulse",
+  "nodeEnv": "production",
+  "agentEnabled": false
+}
+```
+
+## If deployment fails
+
+Check these first:
+
+1. Missing `DATABASE_URL`
+2. MySQL service not reachable from the app
+3. Build error from TypeScript or missing dependencies
+4. Secrets pasted with extra quotes or spaces
+5. Agent enabled without required wallet/API credentials
+
+## Domain setup
+
+After Railway gives you a working URL, connect a custom domain like:
+
+```text
+basepulse.xyz
+app.basepulse.xyz
+basepulse.dev
+```
+
+Use the DNS records Railway provides. Keep `basepulse.manus.space` only as an old demo URL, not the main production identity.

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE"
+  },
+  "deploy": {
+    "startCommand": "pnpm start",
+    "healthcheckPath": "/healthz",
+    "healthcheckTimeout": 120,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -36,6 +36,16 @@ async function startServer() {
   app.use(express.json({ limit: "50mb" }));
   app.use(express.urlencoded({ limit: "50mb", extended: true }));
 
+  app.get("/healthz", (_req: Request, res: Response) => {
+    res.status(200).json({
+      status: "ok",
+      service: "basepulse",
+      nodeEnv: process.env.NODE_ENV || "development",
+      agentEnabled: process.env.BASEPULSE_AGENT_ENABLED === "true",
+      timestamp: new Date().toISOString(),
+    });
+  });
+
   // ── Registry proxy: /api/registry/* → https://base.org/api/registry/* ──────
   app.use("/api/registry", (req: Request, res: Response) => {
     const upstreamPath = "/api/registry" + req.path + (req.url.includes("?") ? req.url.slice(req.url.indexOf("?")) : "");
@@ -100,15 +110,20 @@ async function startServer() {
     console.log(`Server running on http://localhost:${port}/`);
   });
 
-  // Start the autonomous agent loop
-  scheduleAutonomousLoop({
-    enabled: true,
-    intervalMinutes: 15,
-    minSentimentScore: 60,
-    minMentions: 5,
-    minVolume24hUSD: 100000,
-    maxDeploymentsPerDay: 10,
-  });
+  if (process.env.BASEPULSE_AGENT_ENABLED === "true") {
+    // Start the autonomous agent loop only when explicitly enabled.
+    // This prevents accidental token deployments when hosting the dashboard.
+    scheduleAutonomousLoop({
+      enabled: true,
+      intervalMinutes: parseInt(process.env.BASEPULSE_AGENT_INTERVAL_MINUTES || "15"),
+      minSentimentScore: parseInt(process.env.BASEPULSE_MIN_SENTIMENT_SCORE || "60"),
+      minMentions: parseInt(process.env.BASEPULSE_MIN_MENTIONS || "5"),
+      minVolume24hUSD: parseInt(process.env.BASEPULSE_MIN_VOLUME_24H_USD || "100000"),
+      maxDeploymentsPerDay: parseInt(process.env.BASEPULSE_MAX_DEPLOYMENTS_PER_DAY || "10"),
+    });
+  } else {
+    console.log("BasePulse autonomous agent loop is disabled. Set BASEPULSE_AGENT_ENABLED=true to enable it.");
+  }
 }
 
 startServer().catch(console.error);


### PR DESCRIPTION
## Summary

This PR prepares BasePulse to move off the temporary Manus-hosted URL and deploy as a real production app from GitHub.

### Added
- `Dockerfile` for production container deployment
- `railway.json` for Railway deployment with `/healthz` health checks
- `.dockerignore` to keep builds smaller and avoid copying secrets/logs
- `PRODUCTION_DEPLOYMENT.md` with step-by-step deployment instructions

### Changed
- Added `/healthz` endpoint to the Express server
- Made the autonomous agent loop opt-in using `BASEPULSE_AGENT_ENABLED=true`
- Added environment-variable controls for agent safety limits

## Why

`basepulse.manus.space` appears to be a broken/expired/unattached Manus deployment. The GitHub repo still exists, but it needs production-hosting config so the app can be deployed somewhere stable like Railway.

## Safety note

The autonomous token deployment loop now stays disabled by default. This avoids accidental onchain actions when the dashboard boots in production.

## Next steps after merge

1. Connect the repo to Railway.
2. Add a MySQL database.
3. Set `DATABASE_URL` and required secrets.
4. Deploy.
5. Check `/healthz`.
6. Only enable `BASEPULSE_AGENT_ENABLED=true` after wallet/API secrets and deployment limits are confirmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health check endpoint (`/healthz`) for production monitoring and deployment health verification.
  * Autonomous agent execution is now configurable via environment variable, enabling safer production deployments.

* **Documentation**
  * Comprehensive production deployment guide with environment variable reference, safety considerations, and troubleshooting steps.

* **Chores**
  * Added Docker containerization and Railway deployment configuration for production environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abuchtela/BasePulse/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->